### PR TITLE
fix(simulation): empty green lane must yield to busy lanes

### DIFF
--- a/main.py
+++ b/main.py
@@ -53,11 +53,14 @@ def main():
             
             state = intersection.step(dt)
 
-            if intersection.cycle_complete():
+            # Re-plan whenever a phase boundary is hit (i.e. phase_time was
+            # just reset to 0). This makes the AI react every ~10–60 s
+            # instead of only once per full rotation.
+            phase_just_changed = state.current_phase_time == 0
+            if phase_just_changed or intersection.cycle_complete():
                 if controls.ai_mode:
                     plan = agent.act(state)
                     intersection.apply_timing(plan)
-                    # The lane that received the most green time this cycle
                     last_priority = max(plan.durations, key=plan.durations.get)
                 else:
                     intersection.apply_timing(FIXED_PLAN)

--- a/src/simulation/intersection.py
+++ b/src/simulation/intersection.py
@@ -16,6 +16,7 @@ from config import (
     IntersectionState,
     LightState,
     MAX_CARS_PER_LANE,
+    MIN_GREEN_TIME,
     TimingPlan,
 )
 from src.math_models.probability import sample_arrivals
@@ -80,8 +81,25 @@ class Intersection:
                 self.total_wait += v.wait_time
                 self.passed += 1
 
-        # 4. Phase transition when the timer expires
-        if self.phase_time >= self.timing[self.current_phase_dir]:
+        # 4. Phase transition
+        #    a) Normal end-of-phase: timer expired
+        #    b) Smart early-skip: current green lane is empty AND some other
+        #       lane has cars waiting AND we've already served the minimum
+        #       green time. Without this, an empty lane holds green for the
+        #       full duration while busy lanes wait.
+        timer_expired = self.phase_time >= self.timing[self.current_phase_dir]
+        current_empty = len(self.queues[self.current_phase_dir]) == 0
+        others_have_demand = any(
+            len(self.queues[d]) > 0
+            for d in Direction
+            if d is not self.current_phase_dir
+        )
+        early_skip = (
+            current_empty
+            and others_have_demand
+            and self.phase_time >= MIN_GREEN_TIME
+        )
+        if timer_expired or early_skip:
             self._next_phase()
 
         return self.get_state()
@@ -90,24 +108,42 @@ class Intersection:
     # Phase transition
     # ------------------------------------------------------------------
     def _next_phase(self):
-        """Rotate green light to the next direction (round-robin)."""
+        """Pick the next green lane.
+
+        Priority order:
+          1. The non-current lane with the largest queue (demand-driven).
+          2. If every other lane is also empty, fall back to plain
+             round-robin so the simulation always makes progress.
+        Cycle counter still advances every 4 transitions, so the agent's
+        cycle_complete() trigger continues to fire on the same cadence.
+        """
         order = list(Direction)
-        idx = (order.index(self.current_phase_dir) + 1) % 4
+        prev = self.current_phase_dir
+        idx = (order.index(prev) + 1) % 4
+        round_robin_next = order[idx]
 
-        logger.info(
-            "Transition: %s -> %s",
-            self.current_phase_dir.name,
-            order[idx].name,
-        )
+        # Demand-driven choice across the other three lanes
+        candidates = [d for d in Direction if d is not prev]
+        busiest = max(candidates, key=lambda d: len(self.queues[d]))
+        if len(self.queues[busiest]) > 0:
+            chosen = busiest
+        else:
+            chosen = round_robin_next  # everyone empty → just rotate
 
-        self.lights[self.current_phase_dir] = LightState.RED
-        self.current_phase_dir = order[idx]
-        self.lights[self.current_phase_dir] = LightState.GREEN
+        logger.info("Transition: %s -> %s", prev.name, chosen.name)
+
+        self.lights[prev] = LightState.RED
+        self.current_phase_dir = chosen
+        self.lights[chosen] = LightState.GREEN
         self.phase_time = 0
 
-        if idx == 0:
+        # Cycle counter: increments after every 4 transitions regardless of
+        # which direction was picked, so the agent re-plans on a fixed cadence.
+        self._transitions_since_cycle = getattr(self, "_transitions_since_cycle", 0) + 1
+        if self._transitions_since_cycle >= 4:
             self.cycle += 1
             self._just_completed_cycle = True
+            self._transitions_since_cycle = 0
 
     # Backwards-compatible alias (some tests / docs reference this name)
     def _transition_phase(self):

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -98,6 +98,53 @@ def test_cycle_complete_flag():
     assert completed_once
 
 
+# ── Smart phase selection (the bug fix) ──────────────────────────────────
+
+def test_empty_lane_yields_to_busy_lane():
+    """An empty green lane must yield to a busy lane after MIN_GREEN_TIME."""
+    from config import LightState, MIN_GREEN_TIME
+    from src.simulation.vehicle import Vehicle
+
+    inter = Intersection(arrival_rate=0.0)  # no random arrivals
+    inter.current_phase_dir = Direction.EAST
+    for d in Direction:
+        inter.lights[d] = LightState.RED
+    inter.lights[Direction.EAST] = LightState.GREEN
+    inter.queues[Direction.NORTH] = [Vehicle(Direction.NORTH, 0.0) for _ in range(8)]
+
+    # Step through enough time to pass MIN_GREEN_TIME
+    for _ in range(MIN_GREEN_TIME + 2):
+        inter.step(1.0)
+
+    assert inter.lights[Direction.NORTH] == LightState.GREEN
+    assert inter.lights[Direction.EAST] == LightState.RED
+
+
+def test_next_phase_picks_busiest_lane():
+    """When the timer expires, the chosen direction should be the one with the most cars."""
+    from src.simulation.vehicle import Vehicle
+
+    inter = Intersection(arrival_rate=0.0)
+    inter.current_phase_dir = Direction.NORTH
+    inter.queues[Direction.SOUTH] = [Vehicle(Direction.SOUTH, 0.0) for _ in range(2)]
+    inter.queues[Direction.WEST] = [Vehicle(Direction.WEST, 0.0) for _ in range(9)]
+    inter.queues[Direction.EAST] = [Vehicle(Direction.EAST, 0.0) for _ in range(4)]
+
+    inter._next_phase()
+
+    assert inter.current_phase_dir == Direction.WEST   # 9 > 4 > 2
+
+
+def test_all_empty_falls_back_to_round_robin():
+    """If every lane is empty, just rotate to keep the simulation alive."""
+    inter = Intersection(arrival_rate=0.0)
+    inter.current_phase_dir = Direction.NORTH
+    # all queues empty
+    inter._next_phase()
+    # Round-robin: NORTH → SOUTH next
+    assert inter.current_phase_dir == Direction.SOUTH
+
+
 # ── Vehicle ──────────────────────────────────────────────────────────────
 
 def test_vehicle_basic_fields():


### PR DESCRIPTION
## Bug
On the live demo the AI looked broken: an empty lane held the green light for its full timer while busy lanes piled up.

## Root causes
1. `_next_phase()` blindly rotated `N→S→E→W` regardless of demand
2. `step()` only ended a phase when `phase_time >= timing[current]`, so an empty green lane sat for 30 s
3. `main.py` only re-planned on **full-cycle completion** (~120 s cadence), so the SA optimiser reacted too slowly

## Fix
- **Demand-driven phase selection**: `_next_phase()` now picks the lane with the largest queue among the 3 non-current lanes. Falls back to round-robin only when every lane is empty
- **Early skip**: if the current green lane is empty AND another lane has cars AND we've served `MIN_GREEN_TIME` (10 s safety floor), end the phase immediately
- **Faster re-planning**: `main.py` re-plans on every phase boundary, not just full cycles
- **Cycle counter decoupled** from phase index — still increments every 4 transitions so `cycle_complete()` cadence is unchanged

## Test plan
- [x] **136 / 136 tests pass** (was 133 — added 3 behavioural tests)
- [x] `test_empty_lane_yields_to_busy_lane` — proves the early-skip works
- [x] `test_next_phase_picks_busiest_lane` — proves demand-driven choice (9 cars beats 4 beats 2)
- [x] `test_all_empty_falls_back_to_round_robin` — keeps simulation alive when idle
- [x] Manual run: scenario with 10 cars on NORTH, empty EAST green → after 10 s green moved to NORTH and 5 cars cleared in 5 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)