### PR TITLE
feat(simulation): add proper YELLOW phase between GREEN and RED

### DIFF
--- a/config.py
+++ b/config.py
@@ -40,6 +40,7 @@ class TimingPlan:
 MAX_CARS_PER_LANE = 30
 MIN_GREEN_TIME = 10
 MAX_GREEN_TIME = 60
+YELLOW_DURATION = 2          # seconds: light stays YELLOW before turning RED
 SIMULATION_FPS = 30
 ARRIVAL_RATE_DEFAULT = 0.3   # cars per second (Poisson lambda)
 

--- a/src/simulation/intersection.py
+++ b/src/simulation/intersection.py
@@ -18,6 +18,7 @@ from config import (
     MAX_CARS_PER_LANE,
     MIN_GREEN_TIME,
     TimingPlan,
+    YELLOW_DURATION,
 )
 from src.math_models.probability import sample_arrivals
 from src.simulation.vehicle import Vehicle
@@ -41,6 +42,10 @@ class Intersection:
         self.elapsed = 0.0
         self.current_phase_dir = Direction.NORTH
         self._just_completed_cycle = False
+
+        # Yellow-phase state. When True, the current direction is on YELLOW;
+        # phase_time is counting down YELLOW_DURATION before the rotation.
+        self._in_yellow = False
 
         # Arrival model (live-tunable from the dashboard)
         self.arrival_rate = arrival_rate
@@ -75,38 +80,51 @@ class Intersection:
                 v.wait_time += dt
 
         # 3. Throughput on the green lane (1 car / sec)
-        if int(self.elapsed) > int(self.elapsed - dt):
+        #    Cars only cross while the light is GREEN — never on YELLOW or RED.
+        if (
+            not self._in_yellow
+            and self.lights[self.current_phase_dir] is LightState.GREEN
+            and int(self.elapsed) > int(self.elapsed - dt)
+        ):
             if self.queues[self.current_phase_dir]:
                 v = self.queues[self.current_phase_dir].pop(0)
                 self.total_wait += v.wait_time
                 self.passed += 1
 
-        # 4. Phase transition
-        #    a) Normal end-of-phase: timer expired
-        #    b) Smart early-skip: current green lane is empty AND some other
-        #       lane has cars waiting AND we've already served the minimum
-        #       green time. Without this, an empty lane holds green for the
-        #       full duration while busy lanes wait.
-        timer_expired = self.phase_time >= self.timing[self.current_phase_dir]
-        current_empty = len(self.queues[self.current_phase_dir]) == 0
-        others_have_demand = any(
-            len(self.queues[d]) > 0
-            for d in Direction
-            if d is not self.current_phase_dir
-        )
-        early_skip = (
-            current_empty
-            and others_have_demand
-            and self.phase_time >= MIN_GREEN_TIME
-        )
-        if timer_expired or early_skip:
-            self._next_phase()
+        # 4. Phase machine: GREEN → YELLOW → (next) GREEN
+        if self._in_yellow:
+            # Currently amber-warning the cars; rotate when the timer is up
+            if self.phase_time >= YELLOW_DURATION:
+                self._next_phase()
+        else:
+            # Currently green — decide whether to begin the yellow transition
+            timer_expired = self.phase_time >= self.timing[self.current_phase_dir]
+            current_empty = len(self.queues[self.current_phase_dir]) == 0
+            others_have_demand = any(
+                len(self.queues[d]) > 0
+                for d in Direction
+                if d is not self.current_phase_dir
+            )
+            early_skip = (
+                current_empty
+                and others_have_demand
+                and self.phase_time >= MIN_GREEN_TIME
+            )
+            if timer_expired or early_skip:
+                self._begin_yellow()
 
         return self.get_state()
 
     # ------------------------------------------------------------------
     # Phase transition
     # ------------------------------------------------------------------
+    def _begin_yellow(self) -> None:
+        """Switch the current GREEN lane to YELLOW and start the warning timer."""
+        self.lights[self.current_phase_dir] = LightState.YELLOW
+        self.phase_time = 0
+        self._in_yellow = True
+        logger.info("Yellow: %s", self.current_phase_dir.name)
+
     def _next_phase(self):
         """Pick the next green lane.
 
@@ -136,6 +154,7 @@ class Intersection:
         self.current_phase_dir = chosen
         self.lights[chosen] = LightState.GREEN
         self.phase_time = 0
+        self._in_yellow = False
 
         # Cycle counter: increments after every 4 transitions regardless of
         # which direction was picked, so the agent re-plans on a fixed cadence.

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -98,6 +98,61 @@ def test_cycle_complete_flag():
     assert completed_once
 
 
+# ── Yellow phase ─────────────────────────────────────────────────────────
+
+def test_yellow_phase_inserted_between_green_and_red():
+    """A green phase ends with a YELLOW window before the next direction goes green."""
+    from config import LightState, YELLOW_DURATION
+    from src.simulation.vehicle import Vehicle
+
+    inter = Intersection(arrival_rate=0.0)
+    inter.timing = {d: 3 for d in Direction}        # short green so we hit the boundary fast
+    # Add demand on every other lane so early-skip / next-phase has somewhere to go
+    for d in (Direction.SOUTH, Direction.EAST, Direction.WEST):
+        inter.queues[d] = [Vehicle(d, 0.0)]
+
+    # Step until the green direction's light turns YELLOW
+    saw_yellow = False
+    saw_red_after_yellow = False
+    prev_dir = inter.current_phase_dir
+    for _ in range(60):
+        inter.step(0.5)
+        if inter.lights[prev_dir] == LightState.YELLOW:
+            saw_yellow = True
+        if saw_yellow and inter.lights[prev_dir] == LightState.RED:
+            saw_red_after_yellow = True
+            break
+
+    assert saw_yellow,            "expected the outgoing direction to flash YELLOW"
+    assert saw_red_after_yellow,  "expected YELLOW → RED after the yellow window"
+
+
+def test_no_throughput_during_yellow():
+    """Cars must not pass while the light is YELLOW."""
+    from config import LightState
+    from src.simulation.vehicle import Vehicle
+
+    inter = Intersection(arrival_rate=0.0)
+    inter.queues[Direction.NORTH] = [Vehicle(Direction.NORTH, 0.0) for _ in range(5)]
+    # Force into yellow state for NORTH
+    inter.lights[Direction.NORTH] = LightState.YELLOW
+    inter._in_yellow = True
+    inter.phase_time = 0
+    inter.current_phase_dir = Direction.NORTH
+
+    before = inter.passed
+    # Step a sub-second amount — even though int(elapsed) ticks over, no car passes
+    for _ in range(3):
+        inter.step(0.5)
+    # The phase should have transitioned out of yellow at some point, but cars
+    # released after that come from the NEW green direction — not NORTH.
+    # NORTH's queue must NOT have shrunk during the YELLOW window.
+    assert before == 0
+    # And after enough time passes, eventually the new direction releases cars
+    # but not from NORTH (no other queues populated → none should pass)
+    assert inter.passed == 0
+
+
 # ── Smart phase selection (the bug fix) ──────────────────────────────────
 
 def test_empty_lane_yields_to_busy_lane():


### PR DESCRIPTION
## Summary
The renderer already supported YELLOW lights but the simulation never used them — lights flipped instantly GREEN ↔ RED. This adds a real 2-second amber-warning window between every GREEN phase and the next direction's GREEN.

## Behaviour
- After every GREEN phase (whether the timer expired or the smart early-skip kicked in), the outgoing lane turns YELLOW for \`YELLOW_DURATION = 2\` seconds, then RED, then the chosen new lane turns GREEN
- Cars cannot cross while the light is YELLOW (throughput now requires GREEN)
- Cycle counter and \`cycle_complete()\` cadence unchanged — the agent re-plans on the same beat

## Test plan
- [x] **140 / 140 tests pass** (was 138 — added 2 yellow-phase tests)
- [x] \`test_yellow_phase_inserted_between_green_and_red\` — proves GREEN → YELLOW → RED ordering
- [x] \`test_no_throughput_during_yellow\` — proves cars don't cross on yellow
- [x] Manual run: yellow flashes visibly before each green rotation in the demo

🤖 Generated with [Claude Code](https://claude.com/claude-code)