### PR TITLE
fix(ui): increase window height so dashboard sliders aren't clipped

### DIFF
--- a/src/ui/renderer.py
+++ b/src/ui/renderer.py
@@ -24,9 +24,11 @@ from config import Direction, IntersectionState, LightState
 # ---------------------------------------------------------------------------
 # Window / palette
 # ---------------------------------------------------------------------------
-WIDTH, HEIGHT = 900, 700
+WIDTH, HEIGHT = 900, 760
 ROAD_WIDTH = 140
-CENTER = (WIDTH // 2, HEIGHT // 2)
+# Render the intersection in the upper region so the bottom 200 px is reserved
+# for the dashboard (sliders, buttons, chart).
+CENTER = (WIDTH // 2, 280)
 
 PALETTE = {
     "grass":        (34, 139, 70),


### PR DESCRIPTION
## Bug
The control panel starts at y=540 and reserves 200 px below it (sliders at y=700, chart ends at y=715). But the window was only 700 px tall — so the **arrival-rate and sim-speed sliders were drawn off-screen** and the user couldn't drag them.

## Fix
- \`WIDTH × HEIGHT = 900 × 760\` (was 900 × 700)
- \`CENTER = (WIDTH // 2, 280)\` so the intersection sits in the upper region and the bottom 200 px stays reserved for the dashboard

## Test plan
- [x] All 140 tests pass
- [x] Manual run: both sliders fully visible and draggable